### PR TITLE
Implement basic authentication demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# codexpage
+# Sistema de Autenticación PHP
+
+Este proyecto es un ejemplo sencillo de autenticación con control de acceso mediante niveles numéricos.
+
+## Configuración
+
+1. Cree una base de datos MySQL e importe `database_setup.sql`.
+2. Edite el archivo `config.php` con sus credenciales.
+3. Coloque los archivos PHP en su servidor web con soporte PHP 8.
+
+## Uso en nuevas páginas
+
+Incluya al inicio de cada página protegida:
+
+```php
+require_once __DIR__.'/auth.php';
+enforce_access([ 'rule' => 'authenticated' ]); // o la regla que corresponda
+```
+
+Reglas disponibles:
+
+- `public` – acceso para cualquiera
+- `authenticated` – solo usuarios logueados
+- `ids` – solo para ciertos IDs (`ids => [1,2]`)
+- `range` – rango de niveles (`min` y `max`)
+- `except_ids` – lista de IDs excluidos
+
+Los usuarios con nivel 100 tienen acceso total.

--- a/admin_users_lv100.php
+++ b/admin_users_lv100.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__.'/auth.php';
+$user = get_current_user();
+if (!$user || $user['level'] != 100) {
+    enforce_access(['rule' => 'ids', 'ids' => []]); // will redirect
+}
+
+$pdo = get_db_connection();
+
+if (isset($_POST['create'])) {
+    $stmt = $pdo->prepare('INSERT INTO users (email, password, name, level) VALUES (?,?,?,?)');
+    $lvl = min((int)$_POST['level'], 99);
+    $stmt->execute([
+        $_POST['email'],
+        password_hash($_POST['password'], PASSWORD_DEFAULT),
+        $_POST['name'],
+        $lvl
+    ]);
+}
+
+if (isset($_POST['update'])) {
+    $id = (int)$_POST['id'];
+    $level = min((int)$_POST['level'], 99);
+    $stmt = $pdo->prepare('UPDATE users SET email=?, name=?, level=? WHERE id=? AND level<100');
+    $stmt->execute([$_POST['email'], $_POST['name'], $level, $id]);
+}
+
+if (isset($_POST['delete'])) {
+    $id = (int)$_POST['id'];
+    $stmt = $pdo->prepare('DELETE FROM users WHERE id=? AND level<100');
+    $stmt->execute([$id]);
+}
+
+$stmt = $pdo->query('SELECT * FROM users WHERE level<100');
+$users = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestión Usuarios LV100</title>
+</head>
+<body>
+    <h1>Usuarios Nivel < 100</h1>
+    <table border="1" cellpadding="5">
+        <tr><th>ID</th><th>Email</th><th>Nombre</th><th>Nivel</th><th>Acciones</th></tr>
+        <?php foreach ($users as $u): ?>
+            <tr>
+                <form method="post">
+                    <td><?php echo $u['id']; ?><input type="hidden" name="id" value="<?php echo $u['id']; ?>"></td>
+                    <td><input type="email" name="email" value="<?php echo htmlspecialchars($u['email']); ?>"></td>
+                    <td><input type="text" name="name" value="<?php echo htmlspecialchars($u['name']); ?>"></td>
+                    <td><input type="number" name="level" value="<?php echo $u['level']; ?>" min="1" max="99"></td>
+                    <td>
+                        <button name="update" value="1">Guardar</button>
+                        <button name="delete" value="1" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+                    </td>
+                </form>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <h2>Crear Usuario</h2>
+    <form method="post">
+        <label>Email: <input type="email" name="email" required></label>
+        <label>Nombre: <input type="text" name="name" required></label>
+        <label>Contraseña: <input type="password" name="password" required></label>
+        <label>Nivel: <input type="number" name="level" value="1" min="1" max="99"></label>
+        <button name="create" value="1">Crear</button>
+    </form>
+</body>
+</html>

--- a/admin_users_lv90.php
+++ b/admin_users_lv90.php
@@ -1,0 +1,70 @@
+<?php
+require_once __DIR__.'/auth.php';
+$user = get_current_user();
+if (!$user || $user['level'] <= 90) {
+    enforce_access(['rule' => 'range', 'min' => 91, 'max' => 100]);
+}
+
+$pdo = get_db_connection();
+
+if (isset($_POST['create'])) {
+    $stmt = $pdo->prepare('INSERT INTO users (email, password, name, level) VALUES (?,?,?,?)');
+    $stmt->execute([
+        $_POST['email'],
+        password_hash($_POST['password'], PASSWORD_DEFAULT),
+        $_POST['name'],
+        min((int)$_POST['level'], 89)
+    ]);
+}
+
+if (isset($_POST['update'])) {
+    $id = (int)$_POST['id'];
+    $level = min((int)$_POST['level'], 89);
+    $stmt = $pdo->prepare('UPDATE users SET email=?, name=?, level=? WHERE id=? AND level<90');
+    $stmt->execute([$_POST['email'], $_POST['name'], $level, $id]);
+}
+
+if (isset($_POST['delete'])) {
+    $id = (int)$_POST['id'];
+    $stmt = $pdo->prepare('DELETE FROM users WHERE id=? AND level<90');
+    $stmt->execute([$id]);
+}
+
+$stmt = $pdo->query('SELECT * FROM users WHERE level<90');
+$users = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestión Usuarios LV90</title>
+</head>
+<body>
+    <h1>Usuarios Nivel < 90</h1>
+    <table border="1" cellpadding="5">
+        <tr><th>ID</th><th>Email</th><th>Nombre</th><th>Nivel</th><th>Acciones</th></tr>
+        <?php foreach ($users as $u): ?>
+            <tr>
+                <form method="post">
+                    <td><?php echo $u['id']; ?><input type="hidden" name="id" value="<?php echo $u['id']; ?>"></td>
+                    <td><input type="email" name="email" value="<?php echo htmlspecialchars($u['email']); ?>"></td>
+                    <td><input type="text" name="name" value="<?php echo htmlspecialchars($u['name']); ?>"></td>
+                    <td><input type="number" name="level" value="<?php echo $u['level']; ?>" min="1" max="89"></td>
+                    <td>
+                        <button name="update" value="1">Guardar</button>
+                        <button name="delete" value="1" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+                    </td>
+                </form>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <h2>Crear Usuario</h2>
+    <form method="post">
+        <label>Email: <input type="email" name="email" required></label>
+        <label>Nombre: <input type="text" name="name" required></label>
+        <label>Contraseña: <input type="password" name="password" required></label>
+        <label>Nivel: <input type="number" name="level" value="1" min="1" max="89"></label>
+        <button name="create" value="1">Crear</button>
+    </form>
+</body>
+</html>

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,91 @@
+<?php
+require_once __DIR__.'/db.php';
+
+session_start();
+
+function get_current_user(): ?array {
+    if (isset($_SESSION['user_id'])) {
+        return get_user_by_id($_SESSION['user_id']);
+    }
+    return null;
+}
+
+function get_user_by_id(int $id): ?array {
+    $pdo = get_db_connection();
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');
+    $stmt->execute([$id]);
+    $user = $stmt->fetch();
+    return $user ?: null;
+}
+
+function login(string $email, string $password): bool {
+    $pdo = get_db_connection();
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        return true;
+    }
+    return false;
+}
+
+function logout(): void {
+    session_unset();
+    session_destroy();
+}
+
+function require_login(): void {
+    if (!isset($_SESSION['user_id'])) {
+        header('Location: login.php');
+        exit;
+    }
+}
+
+function check_access(array $config): bool {
+    $user = get_current_user();
+    $level = $user['level'] ?? 0;
+    $user_id = $user['id'] ?? 0;
+
+    // rule: 'public', 'authenticated', 'ids', 'range'
+    $rule = $config['rule'] ?? 'public';
+    $allowed_ids = $config['ids'] ?? [];
+    $min = $config['min'] ?? 1;
+    $max = $config['max'] ?? 100;
+    $except_ids = $config['except_ids'] ?? [];
+
+    if ($level === 100) {
+        return true; // full access for level 100
+    }
+
+    if (in_array($user_id, $except_ids)) {
+        return false;
+    }
+
+    switch ($rule) {
+        case 'public':
+            return true;
+        case 'authenticated':
+            return $level >= 1;
+        case 'ids':
+            return in_array($user_id, $allowed_ids);
+        case 'range':
+            return $level >= $min && $level <= $max;
+        default:
+            return false;
+    }
+}
+
+function enforce_access(array $config): void {
+    $allowed = check_access($config);
+    $user = get_current_user();
+    if (!$allowed) {
+        if ($user) {
+            echo 'Acceso denegado';
+            exit;
+        } else {
+            header('Location: login.php');
+            exit;
+        }
+    }
+}

--- a/config.php
+++ b/config.php
@@ -1,0 +1,10 @@
+<?php
+// Database configuration
+// These should be edited by webmaster
+
+define('DB_HOST', 'srv1789.hstgr.io');
+define('DB_NAME', 'u643065128_phpblog');
+define('DB_USER', 'u643065128_urdinart');
+define('DB_PASSWORD', 'Noctiluca3.'); // Change in production
+define('DB_CHARSET', 'utf8mb4');
+

--- a/database_setup.sql
+++ b/database_setup.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    phone VARCHAR(50) NULL,
+    name VARCHAR(100) NOT NULL,
+    civil_name VARCHAR(100) NULL,
+    location VARCHAR(100) NULL,
+    description TEXT NULL,
+    role VARCHAR(100) NULL,
+    level INT NOT NULL DEFAULT 1,
+    notes TEXT NULL,
+    status VARCHAR(100) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4;
+
+INSERT INTO users (email, password, name, level) VALUES
+ ('lv33@example.com', '$2y$10$9rihK4c1C9AJD5NIE.e1..dolQ2ovwvcS6/fGWGzbm.AKnr8FV3Eq', 'Usuario33', 33),
+ ('lv66@example.com', '$2y$10$9rihK4c1C9AJD5NIE.e1..dolQ2ovwvcS6/fGWGzbm.AKnr8FV3Eq', 'Usuario66', 66),
+ ('lv99@example.com', '$2y$10$9rihK4c1C9AJD5NIE.e1..dolQ2ovwvcS6/fGWGzbm.AKnr8FV3Eq', 'Usuario99', 99),
+ ('lv100@example.com', '$2y$10$9rihK4c1C9AJD5NIE.e1..dolQ2ovwvcS6/fGWGzbm.AKnr8FV3Eq', 'Usuario100', 100);

--- a/db.php
+++ b/db.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__.'/config.php';
+
+function get_db_connection(): PDO {
+    static $pdo = null;
+    if ($pdo === null) {
+        $dsn = 'mysql:host='.DB_HOST.';dbname='.DB_NAME.';charset='.DB_CHARSET;
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ];
+        $pdo = new PDO($dsn, DB_USER, DB_PASSWORD, $options);
+    }
+    return $pdo;
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__.'/auth.php';
+$user = get_current_user();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Inicio</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        nav a { margin-right: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Bienvenido<?php echo $user ? ', '.htmlspecialchars($user['name']) : ''; ?></h1>
+    <nav>
+        <a href="index.php">Inicio</a>
+        <?php if ($user): ?>
+            <a href="profile.php">Perfil</a>
+            <a href="logout.php">Logout</a>
+        <?php else: ?>
+            <a href="login.php">Login</a>
+        <?php endif; ?>
+        <a href="test_public.php">Pública</a>
+        <a href="test_auth.php">Solo Autenticados</a>
+        <a href="test_ids.php">Solo IDs</a>
+        <a href="test_levels.php">Rango de Niveles</a>
+        <a href="test_exception.php">Con Excepción</a>
+    </nav>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__.'/auth.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if (login($email, $password)) {
+        $redirect = $_GET['redirect'] ?? 'index.php';
+        header('Location: '.$redirect);
+        exit;
+    } else {
+        $error = 'Credenciales incorrectas';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <?php if (isset($error)) echo '<p style="color:red">'.$error.'</p>'; ?>
+    <form method="post">
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Contraseña: <input type="password" name="password" required></label><br>
+        <button type="submit">Ingresar</button>
+    </form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__.'/auth.php';
+logout();
+header('Location: index.php');
+exit;

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__.'/auth.php';
+require_login();
+$user = get_current_user();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $pdo = get_db_connection();
+    $fields = ['email','phone','name'];
+    $updates = [];
+    $params = [];
+    foreach ($fields as $f) {
+        if (isset($_POST[$f])) {
+            $updates[] = "$f = ?";
+            $params[] = $_POST[$f];
+        }
+    }
+    if (!empty($_POST['new_password'])) {
+        if (password_verify($_POST['current_password'] ?? '', $user['password'])) {
+            $updates[] = "password = ?";
+            $params[] = password_hash($_POST['new_password'], PASSWORD_DEFAULT);
+        } else {
+            $error = 'Contraseña actual incorrecta';
+        }
+    }
+    if (!$error) {
+        if ($updates) {
+            $params[] = $user['id'];
+            $sql = 'UPDATE users SET '.implode(',',$updates).' WHERE id = ?';
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute($params);
+            header('Location: profile.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Perfil</title>
+</head>
+<body>
+    <h1>Editar Perfil</h1>
+    <?php if (isset($error)) echo '<p style="color:red">'.$error.'</p>'; ?>
+    <form method="post">
+        <label>Email: <input type="email" name="email" value="<?php echo htmlspecialchars($user['email']); ?>" required></label><br>
+        <label>Teléfono: <input type="text" name="phone" value="<?php echo htmlspecialchars($user['phone']); ?>"></label><br>
+        <label>Nombre: <input type="text" name="name" value="<?php echo htmlspecialchars($user['name']); ?>" required></label><br>
+        <label>Contraseña Actual: <input type="password" name="current_password"></label><br>
+        <label>Nueva Contraseña: <input type="password" name="new_password"></label><br>
+        <button type="submit">Guardar</button>
+    </form>
+</body>
+</html>

--- a/test_auth.php
+++ b/test_auth.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__.'/auth.php';
+enforce_access(['rule' => 'authenticated']);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8"><title>Solo Autenticados</title></head>
+<body>
+<h1>Solo Usuarios Autenticados</h1>
+<p>Si ves esto estás logueado.</p>
+</body>
+</html>

--- a/test_exception.php
+++ b/test_exception.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__.'/auth.php';
+enforce_access(['rule' => 'range', 'min' => 30, 'max' => 70, 'except_ids' => [2]]);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8"><title>Con Excepción</title></head>
+<body>
+<h1>Rango 30-70 con excepción</h1>
+<p>El usuario con ID 2 está excluido.</p>
+</body>
+</html>

--- a/test_ids.php
+++ b/test_ids.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__.'/auth.php';
+// IDs permitidos, ej. usuarios nivel 33 y 66
+$allowed_ids = [2,3];
+enforce_access(['rule' => 'ids', 'ids' => $allowed_ids]);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8"><title>IDs Específicos</title></head>
+<body>
+<h1>Solo para IDs Específicos</h1>
+<p>Acceso permitido solo a ciertos usuarios.</p>
+</body>
+</html>

--- a/test_levels.php
+++ b/test_levels.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__.'/auth.php';
+enforce_access(['rule' => 'range', 'min' => 30, 'max' => 70]);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8"><title>Rango de Niveles</title></head>
+<body>
+<h1>Solo para Niveles 30-70</h1>
+<p>Usuarios fuera de este rango o no autenticados no deben ver esto.</p>
+</body>
+</html>

--- a/test_public.php
+++ b/test_public.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__.'/auth.php';
+enforce_access(['rule' => 'public']);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="UTF-8"><title>Publica</title></head>
+<body>
+<h1>Página Pública</h1>
+<p>Accesible por cualquiera.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add database configuration with provided credentials
- create PDO connection and authentication helpers
- add login, logout, profile editing, and simple admin pages
- implement demo pages showing access rules
- provide SQL setup script and usage docs

## Testing
- `apt-get update`
- `apt-get install -y php-cli`


------
https://chatgpt.com/codex/tasks/task_e_684ba034a3f4832c9a13dd1653356e91

## Summary by Sourcery

Implement a PHP-based authentication demo with PDO-backed user management and session-based access control, including login/logout, profile editing, admin CRUD pages for different user levels, demo pages illustrating access rules, plus setup documentation and SQL schema script.

New Features:
- Add config.php and db.php for database credentials and PDO connection handling
- Implement auth.php with session start, login/logout, user retrieval and flexible access checks (public, authenticated, ids, range, except_ids)
- Introduce user pages: index, login, logout and profile editing
- Add admin user management interfaces for level<100 and level 90–100 with create, update and delete operations
- Provide demo pages to showcase each access control rule (public, authenticated, specific IDs, level ranges and exceptions)
- Include database_setup.sql to create the users table and seed sample accounts

Documentation:
- Rewrite README in Spanish with instructions for database setup, configuration, and usage of access enforcement in protected pages