### PR TITLE
Add bulletin board system

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -17,6 +17,7 @@ $pages = ceil($total/$perPage);
 <head>
 <meta charset="UTF-8">
 <title>Archive</title>
+<link rel="stylesheet" href="board.css">
 </head>
 <body>
 <h1>Archive</h1>

--- a/archive.php
+++ b/archive.php
@@ -29,12 +29,6 @@ $pages = ceil($total/$perPage);
 <div>
 <?php for($i=1;$i<=$pages;$i++){ echo '<a href="?page='.$i.'">'.$i.'</a> '; } ?>
 </div>
-<div id="viewOverlay" class="overlay" style="display:none"><div class="modal" id="viewContent"></div></div>
-<script>
-function openView(id){
-  fetch('view_note.php?id='+id).then(r=>r.text()).then(h=>{document.getElementById('viewContent').innerHTML=h;document.getElementById('viewOverlay').style.display='flex';});
-}
-document.getElementById('viewOverlay').addEventListener('click',e=>{if(e.target.id==='viewOverlay'){e.target.style.display='none';}});
-</script>
+<?php include __DIR__.'/overlay.inc.php'; ?>
 </body>
 </html>

--- a/archive.php
+++ b/archive.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__.'/auth.php';
+$pdo = get_db_connection();
+$page = max(1,(int)($_GET['page'] ?? 1));
+$perPage = 20;
+$offset = ($page-1)*$perPage;
+$total = $pdo->query('SELECT COUNT(*) FROM bulletin_notes WHERE deleted=0')->fetchColumn();
+$notes = $pdo->prepare('SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.deleted=0 ORDER BY COALESCE(n.boost_date,n.post_date) DESC LIMIT ? OFFSET ?');
+$notes->bindValue(1,$perPage,PDO::PARAM_INT);
+$notes->bindValue(2,$offset,PDO::PARAM_INT);
+$notes->execute();
+$list = $notes->fetchAll();
+$pages = ceil($total/$perPage);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Archive</title>
+</head>
+<body>
+<h1>Archive</h1>
+<a href="board.php">Back to the board</a> | <a href="search.php">Search</a>
+<ul>
+<?php foreach($list as $n){ ?>
+<li><a href="#" onclick="openView(<?php echo $n['id']; ?>);return false;"><?php echo htmlspecialchars($n['title']);?></a></li>
+<?php } ?>
+</ul>
+<div>
+<?php for($i=1;$i<=$pages;$i++){ echo '<a href="?page='.$i.'">'.$i.'</a> '; } ?>
+</div>
+<div id="viewOverlay" class="overlay" style="display:none"><div class="modal" id="viewContent"></div></div>
+<script>
+function openView(id){
+  fetch('view_note.php?id='+id).then(r=>r.text()).then(h=>{document.getElementById('viewContent').innerHTML=h;document.getElementById('viewOverlay').style.display='flex';});
+}
+document.getElementById('viewOverlay').addEventListener('click',e=>{if(e.target.id==='viewOverlay'){e.target.style.display='none';}});
+</script>
+</body>
+</html>

--- a/board.css
+++ b/board.css
@@ -1,0 +1,10 @@
+/* Shared styles for bulletin board pages */
+body{font-family:Arial, sans-serif;background:#f4f4f4;margin:0;padding:20px;}
+header{display:flex;justify-content:space-between;align-items:center;}
+#board{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px;}
+.note{padding:10px;width:180px;min-height:100px;box-shadow:0 0 5px rgba(0,0,0,0.3);position:relative;cursor:pointer;}
+.note small{display:block;font-size:12px;}
+#newNoteOverlay{display:none;}
+.modal label{display:block;margin-bottom:10px;}
+.overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;}
+.overlay .modal{background:#fff;padding:20px;max-width:400px;width:100%;}

--- a/board.php
+++ b/board.php
@@ -53,15 +53,7 @@ $unpinned = $pdo->query("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN 
 <head>
 <meta charset="UTF-8">
 <title>Bulletin Board</title>
-<style>
-body{font-family:Arial, sans-serif;background:#f4f4f4;margin:0;padding:20px;}
-header{display:flex;justify-content:space-between;align-items:center;}
-#board{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px;}
-.note{padding:10px;width:180px;min-height:100px;box-shadow:0 0 5px rgba(0,0,0,0.3);position:relative;cursor:pointer;}
-.note small{display:block;font-size:12px;}
-#newNoteOverlay{display:none;}
-.modal label{display:block;margin-bottom:10px;}
-</style>
+<link rel="stylesheet" href="board.css">
 </head>
 <body>
 <header>

--- a/board.php
+++ b/board.php
@@ -1,0 +1,102 @@
+<?php
+require_once __DIR__.'/auth.php';
+$pdo = get_db_connection();
+$user = get_current_user();
+
+// Handle create note
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_note'])) {
+    if (!$user) { header('Location: login.php'); exit; }
+    $title = substr(trim($_POST['title'] ?? ''),0,60);
+    $content = substr(trim($_POST['content'] ?? ''),0,350);
+    $hashtags = trim($_POST['hashtags'] ?? '');
+    $hashtags = preg_replace('/\s+/', ' ', $hashtags);
+    if ($title && $content && $hashtags) {
+        $fonts = ['"Comic Sans MS"','"Courier New"','Georgia','Verdana','Arial'];
+        $font = $fonts[array_rand($fonts)];
+        $text_colors = ['#111','#222','#333','#444'];
+        $bg_colors = ['#ffff99','#fffdc4','#f9f9f9','#eaffd0'];
+        $text_color = $text_colors[array_rand($text_colors)];
+        $bg_color = $bg_colors[array_rand($bg_colors)];
+        $stmt = $pdo->prepare('INSERT INTO bulletin_notes (author_id,title,content,hashtags,font,text_color,bg_color) VALUES (?,?,?,?,?,?,?)');
+        $stmt->execute([
+            $user['id'],$title,
+            $content,
+            $hashtags,
+            $font,
+            $text_color,
+            $bg_color
+        ]);
+        header('Location: board.php');
+        exit;
+    }
+}
+
+$pinned = $pdo->query("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.deleted=0 AND n.pinned=1 ORDER BY COALESCE(n.boost_date,n.post_date) DESC LIMIT 10")->fetchAll();
+$unpinned = $pdo->query("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.deleted=0 AND n.pinned=0 ORDER BY COALESCE(n.boost_date,n.post_date) DESC LIMIT 20")->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Bulletin Board</title>
+<style>
+body{font-family:Arial, sans-serif;background:#f4f4f4;margin:0;padding:20px;}
+header{display:flex;justify-content:space-between;align-items:center;}
+#board{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px;}
+.note{padding:10px;width:180px;min-height:100px;box-shadow:0 0 5px rgba(0,0,0,0.3);position:relative;cursor:pointer;}
+.note small{display:block;font-size:12px;}
+.overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;}
+#newNoteOverlay,.viewOverlay{display:none;}
+.overlay .modal{background:#fff;padding:20px;max-width:400px;width:100%;}
+.modal label{display:block;margin-bottom:10px;}
+</style>
+</head>
+<body>
+<header>
+<h1>Bulletin Board</h1>
+<div>
+<button onclick="document.getElementById('newNoteOverlay').style.display='flex'">Post note</button>
+<a href="search.php">Search note</a>
+</div>
+</header>
+<div id="board">
+<?php
+function render_note($n){
+    $rotate = rand(-5,5);
+    $size = 14 + floor(($n['level'] ?? 0)/10);
+    echo '<div class="note" style="background:'.htmlspecialchars($n['bg_color']).';color:'.htmlspecialchars($n['text_color']).';font-family:'.$n['font'].';transform:rotate('.$rotate.'deg);font-size:'.$size.'px" onclick="openView('.$n['id'].')">';
+    echo '<small>'.htmlspecialchars($n['boost_date'] ?: $n['post_date']).'</small>';
+    echo '<strong>'.htmlspecialchars($n['title']).'</strong><br>';
+    echo '<small>'.htmlspecialchars($n['name']).'</small>';
+    echo '</div>';
+}
+foreach($pinned as $n) render_note($n);
+foreach($unpinned as $n) render_note($n);
+?>
+</div>
+<div><a href="archive.php">Go to archive</a></div>
+
+<div class="overlay" id="newNoteOverlay">
+<div class="modal">
+<form method="post">
+<input type="hidden" name="create_note" value="1">
+<label>Title (max 60)<br><input type="text" name="title" maxlength="60" required></label>
+<label>Content (max 350)<br><textarea name="content" maxlength="350" required></textarea></label>
+<label>Hashtags (1-5)<br><input type="text" name="hashtags" required></label>
+<button type="submit">Post</button>
+<button type="button" onclick="document.getElementById('newNoteOverlay').style.display='none'">Cancel</button>
+</form>
+</div>
+</div>
+<div class="overlay" id="viewOverlay"><div class="modal" id="viewContent"></div></div>
+<script>
+function openView(id){
+    fetch('view_note.php?id='+id).then(r=>r.text()).then(html=>{
+        document.getElementById('viewContent').innerHTML=html;
+        document.getElementById('viewOverlay').style.display='flex';
+    });
+}
+document.getElementById('viewOverlay').addEventListener('click',e=>{if(e.target.id==='viewOverlay'){e.target.style.display='none';}});
+</script>
+</body>
+</html>

--- a/bulletin_setup.sql
+++ b/bulletin_setup.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS bulletin_notes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    author_id INT NOT NULL,
+    post_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    boost_date DATETIME DEFAULT NULL,
+    pinned TINYINT(1) NOT NULL DEFAULT 0,
+    deleted TINYINT(1) NOT NULL DEFAULT 0,
+    title VARCHAR(60) NOT NULL,
+    content VARCHAR(350) NOT NULL,
+    hashtags VARCHAR(255) NOT NULL,
+    font VARCHAR(100) NOT NULL,
+    text_color VARCHAR(20) NOT NULL,
+    bg_color VARCHAR(20) NOT NULL
+) CHARACTER SET utf8mb4;
+
+-- Random demo notes
+INSERT INTO bulletin_notes (author_id, post_date, pinned, title, content, hashtags, font, text_color, bg_color)
+VALUES
+    (1, NOW(), 0, 'Sample Note 1', 'This is example content for note 1.', '#tag1', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 2', 'This is example content for note 2.', '#tag2', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 3', 'This is example content for note 3.', '#tag3', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 4', 'This is example content for note 4.', '#tag4', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 5', 'This is example content for note 5.', '#tag5', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 6', 'This is example content for note 6.', '#tag6', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 7', 'This is example content for note 7.', '#tag7', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 8', 'This is example content for note 8.', '#tag8', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 9', 'This is example content for note 9.', '#tag9', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 10', 'This is example content for note 10.', '#tag10', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 11', 'This is example content for note 11.', '#tag11', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 12', 'This is example content for note 12.', '#tag12', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 13', 'This is example content for note 13.', '#tag13', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 14', 'This is example content for note 14.', '#tag14', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 15', 'This is example content for note 15.', '#tag15', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 16', 'This is example content for note 16.', '#tag16', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 17', 'This is example content for note 17.', '#tag17', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 18', 'This is example content for note 18.', '#tag18', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 19', 'This is example content for note 19.', '#tag19', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 20', 'This is example content for note 20.', '#tag20', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 21', 'This is example content for note 21.', '#tag21', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 22', 'This is example content for note 22.', '#tag22', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 23', 'This is example content for note 23.', '#tag23', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 24', 'This is example content for note 24.', '#tag24', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 25', 'This is example content for note 25.', '#tag25', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 26', 'This is example content for note 26.', '#tag26', 'Arial', '#333', '#ffff99'),
+    (3, NOW(), 0, 'Sample Note 27', 'This is example content for note 27.', '#tag27', 'Arial', '#333', '#ffff99'),
+    (4, NOW(), 0, 'Sample Note 28', 'This is example content for note 28.', '#tag28', 'Arial', '#333', '#ffff99'),
+    (1, NOW(), 0, 'Sample Note 29', 'This is example content for note 29.', '#tag29', 'Arial', '#333', '#ffff99'),
+    (2, NOW(), 0, 'Sample Note 30', 'This is example content for note 30.', '#tag30', 'Arial', '#333', '#ffff99');

--- a/csrf.php
+++ b/csrf.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+function csrf_token(): string {
+    if(empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+function csrf_field(): string {
+    return '<input type="hidden" name="csrf_token" value="'.csrf_token().'">';
+}
+function verify_csrf(): bool {
+    return isset($_POST['csrf_token'], $_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $_POST['csrf_token']);
+}

--- a/note_action.php
+++ b/note_action.php
@@ -1,8 +1,10 @@
 <?php
 require_once __DIR__.'/auth.php';
+require_once __DIR__.'/csrf.php';
 require_login();
 $pdo = get_db_connection();
 $id = (int)($_POST['id'] ?? 0);
+if(!verify_csrf()) { die('Invalid CSRF'); }
 $noteStmt = $pdo->prepare('SELECT * FROM bulletin_notes WHERE id=?');
 $noteStmt->execute([$id]);
 $note = $noteStmt->fetch();

--- a/note_action.php
+++ b/note_action.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__.'/auth.php';
+require_login();
+$pdo = get_db_connection();
+$id = (int)($_POST['id'] ?? 0);
+$noteStmt = $pdo->prepare('SELECT * FROM bulletin_notes WHERE id=?');
+$noteStmt->execute([$id]);
+$note = $noteStmt->fetch();
+if(!$note){ die('Not found'); }
+$user = get_current_user();
+if(isset($_POST['boost'])){
+    $pdo->prepare('UPDATE bulletin_notes SET boost_date=NOW() WHERE id=?')->execute([$id]);
+}
+if(isset($_POST['toggle_pin']) && (($user['id']==$note['author_id'] && $user['level']>50) || $user['level']>70)){
+    $new = $note['pinned']?0:1;
+    $pdo->prepare('UPDATE bulletin_notes SET pinned=? WHERE id=?')->execute([$new,$id]);
+}
+if(isset($_POST['delete']) && ($user['id']==$note['author_id'] || $user['level']>80)){
+    $pdo->prepare('UPDATE bulletin_notes SET deleted=1 WHERE id=?')->execute([$id]);
+}
+header('Location: board.php');

--- a/overlay.inc.php
+++ b/overlay.inc.php
@@ -1,0 +1,20 @@
+<style>
+.overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;}
+.overlay .modal{background:#fff;padding:20px;max-width:400px;width:100%;}
+</style>
+<div id="viewOverlay" class="overlay">
+  <div class="modal" id="viewContent"></div>
+</div>
+<script>
+function openView(id){
+  fetch('view_note.php?id='+id).then(r=>r.text()).then(html=>{
+    document.getElementById('viewContent').innerHTML=html;
+    document.getElementById('viewOverlay').style.display='flex';
+  });
+}
+document.addEventListener('DOMContentLoaded',function(){
+  document.getElementById('viewOverlay').addEventListener('click',function(e){
+    if(e.target.id==='viewOverlay'){e.target.style.display='none';}
+  });
+});
+</script>

--- a/overlay.inc.php
+++ b/overlay.inc.php
@@ -1,7 +1,3 @@
-<style>
-.overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);display:none;align-items:center;justify-content:center;}
-.overlay .modal{background:#fff;padding:20px;max-width:400px;width:100%;}
-</style>
 <div id="viewOverlay" class="overlay">
   <div class="modal" id="viewContent"></div>
 </div>

--- a/search.php
+++ b/search.php
@@ -31,12 +31,6 @@ if($query){
 <li><a href="#" onclick="openView(<?php echo $n['id']; ?>);return false;"><?php echo htmlspecialchars($n['title']);?></a></li>
 <?php } ?>
 </ul>
-<div id="viewOverlay" class="overlay" style="display:none"><div class="modal" id="viewContent"></div></div>
-<script>
-function openView(id){
-  fetch('view_note.php?id='+id).then(r=>r.text()).then(h=>{document.getElementById('viewContent').innerHTML=h;document.getElementById('viewOverlay').style.display='flex';});
-}
-document.getElementById('viewOverlay').addEventListener('click',e=>{if(e.target.id==='viewOverlay'){e.target.style.display='none';}});
-</script>
+<?php include __DIR__.'/overlay.inc.php'; ?>
 </body>
 </html>

--- a/search.php
+++ b/search.php
@@ -19,6 +19,7 @@ if($query){
 <head>
 <meta charset="UTF-8">
 <title>Search Notes</title>
+<link rel="stylesheet" href="board.css">
 </head>
 <body>
 <h1>Search Notes</h1>

--- a/search.php
+++ b/search.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__.'/auth.php';
+$pdo = get_db_connection();
+$query = trim($_GET['q'] ?? '');
+$results = [];
+if($query){
+    if(strpos($query,'#')===0){
+        $stmt = $pdo->prepare("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.deleted=0 AND n.hashtags LIKE ? ORDER BY COALESCE(n.boost_date,n.post_date) DESC");
+        $stmt->execute(['%'.$query.'%']);
+    } else {
+        $stmt = $pdo->prepare("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.deleted=0 AND u.name LIKE ? ORDER BY COALESCE(n.boost_date,n.post_date) DESC");
+        $stmt->execute(['%'.$query.'%']);
+    }
+    $results = $stmt->fetchAll();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Search Notes</title>
+</head>
+<body>
+<h1>Search Notes</h1>
+<form method="get">
+<input type="text" name="q" value="<?php echo htmlspecialchars($query);?>" placeholder="#hashtag or author">
+<button type="submit">Search</button>
+</form>
+<ul>
+<?php foreach($results as $n){ ?>
+<li><a href="#" onclick="openView(<?php echo $n['id']; ?>);return false;"><?php echo htmlspecialchars($n['title']);?></a></li>
+<?php } ?>
+</ul>
+<div id="viewOverlay" class="overlay" style="display:none"><div class="modal" id="viewContent"></div></div>
+<script>
+function openView(id){
+  fetch('view_note.php?id='+id).then(r=>r.text()).then(h=>{document.getElementById('viewContent').innerHTML=h;document.getElementById('viewOverlay').style.display='flex';});
+}
+document.getElementById('viewOverlay').addEventListener('click',e=>{if(e.target.id==='viewOverlay'){e.target.style.display='none';}});
+</script>
+</body>
+</html>

--- a/view_note.php
+++ b/view_note.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__.'/auth.php';
+require_once __DIR__.'/csrf.php';
 $pdo = get_db_connection();
 $id = (int)($_GET['id'] ?? 0);
 $note = $pdo->prepare("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.id=?");
@@ -8,7 +9,7 @@ $n = $note->fetch();
 if(!$n){ echo 'Note not found'; exit; }
 $size = 14 + floor(($n['level'] ?? 0)/10);
 ?>
-<div style="background:<?php echo htmlspecialchars($n['bg_color']);?>;color:<?php echo htmlspecialchars($n['text_color']);?>;font-family:<?php echo $n['font'];?>;font-size:<?php echo $size;?>px;padding:10px;">
+<div style="background:<?php echo htmlspecialchars($n['bg_color']);?>;color:<?php echo htmlspecialchars($n['text_color']);?>;font-family:<?php echo htmlspecialchars($n['font'],ENT_QUOTES);?>;font-size:<?php echo $size;?>px;padding:10px;">
 <p style="font-size:smaller;">
 <?php if($n['boost_date']){ ?>
 <span style="text-decoration:line-through;"><?php echo htmlspecialchars($n['post_date']);?></span>
@@ -25,12 +26,14 @@ $size = 14 + floor(($n['level'] ?? 0)/10);
 <?php if(get_current_user()){ ?>
 <form method="post" action="note_action.php" style="display:inline">
 <input type="hidden" name="id" value="<?php echo $n['id']; ?>">
+<?php echo csrf_field(); ?>
 <button name="boost">Boost</button>
 </form>
 <?php }
 if($user && ($user['id']==$n['author_id'] && $user['level']>50 || $user['level']>70)){ ?>
 <form method="post" action="note_action.php" style="display:inline">
 <input type="hidden" name="id" value="<?php echo $n['id']; ?>">
+<?php echo csrf_field(); ?>
 <button name="toggle_pin"><?php echo $n['pinned']? 'Unpin':'Pin'; ?></button>
 </form>
 <?php }
@@ -40,6 +43,7 @@ if($user){ ?>
 if($user && ($user['id']==$n['author_id'] || $user['level']>80)){ ?>
 <form method="post" action="note_action.php" style="display:inline" onsubmit="return confirm('Delete note?')">
 <input type="hidden" name="id" value="<?php echo $n['id']; ?>">
+<?php echo csrf_field(); ?>
 <button name="delete">Delete</button>
 </form>
 <?php } ?>

--- a/view_note.php
+++ b/view_note.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__.'/auth.php';
+$pdo = get_db_connection();
+$id = (int)($_GET['id'] ?? 0);
+$note = $pdo->prepare("SELECT n.*, u.name, u.level FROM bulletin_notes n JOIN users u ON u.id=n.author_id WHERE n.id=?");
+$note->execute([$id]);
+$n = $note->fetch();
+if(!$n){ echo 'Note not found'; exit; }
+$size = 14 + floor(($n['level'] ?? 0)/10);
+?>
+<div style="background:<?php echo htmlspecialchars($n['bg_color']);?>;color:<?php echo htmlspecialchars($n['text_color']);?>;font-family:<?php echo $n['font'];?>;font-size:<?php echo $size;?>px;padding:10px;">
+<p style="font-size:smaller;">
+<?php if($n['boost_date']){ ?>
+<span style="text-decoration:line-through;"><?php echo htmlspecialchars($n['post_date']);?></span>
+<span style="color:darkred;"> <?php echo htmlspecialchars($n['boost_date']);?></span>
+<?php } else { echo htmlspecialchars($n['post_date']); } ?>
+</p>
+<h3 style="margin:0;font-weight:bold;font-size:<?php echo $size+2;?>px;"><?php echo htmlspecialchars($n['title']);?></h3>
+<p><?php echo nl2br(htmlspecialchars($n['content']));?></p>
+<p style="opacity:0.7;"><?php echo htmlspecialchars($n['hashtags']);?></p>
+<p style="text-align:right;font-style:italic;font-size:smaller;opacity:0.9;"><?php echo htmlspecialchars($n['name']);?></p>
+</div>
+<div style="margin-top:10px;">
+<button onclick="document.getElementById('viewOverlay').style.display='none'">Close</button>
+<?php if(get_current_user()){ ?>
+<form method="post" action="note_action.php" style="display:inline">
+<input type="hidden" name="id" value="<?php echo $n['id']; ?>">
+<button name="boost">Boost</button>
+</form>
+<?php }
+if($user && ($user['id']==$n['author_id'] && $user['level']>50 || $user['level']>70)){ ?>
+<form method="post" action="note_action.php" style="display:inline">
+<input type="hidden" name="id" value="<?php echo $n['id']; ?>">
+<button name="toggle_pin"><?php echo $n['pinned']? 'Unpin':'Pin'; ?></button>
+</form>
+<?php }
+if($user){ ?>
+<button onclick="navigator.clipboard.writeText(document.getElementById('viewContent').innerText)">Copy</button>
+<?php }
+if($user && ($user['id']==$n['author_id'] || $user['level']>80)){ ?>
+<form method="post" action="note_action.php" style="display:inline" onsubmit="return confirm('Delete note?')">
+<input type="hidden" name="id" value="<?php echo $n['id']; ?>">
+<button name="delete">Delete</button>
+</form>
+<?php } ?>
+</div>


### PR DESCRIPTION
## Summary
- add bulletin board pages and actions
- add SQL setup file with sample notes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ba33dd51c832c82bbd1e3eee3a3b7

## Summary by Sourcery

Add a bulletin board system with pages for posting, viewing, searching, and archiving user notes, along with note action handling and sample data setup.

New Features:
- Implement main board page for creating and displaying notes with randomized styling
- Introduce modal view for individual notes with boost, pin/unpin, delete, and copy actions
- Add search page to filter notes by hashtag or author
- Add archive page with pagination to browse past notes
- Implement note_action endpoint to process boost, pin/unpin, and delete operations
- Add SQL setup script for bulletin_notes table with sample demo entries

Enhancements:
- Randomize fonts, text colors, and background colors for notes